### PR TITLE
Update qr_code_dart_scan.dart

### DIFF
--- a/lib/qr_code_dart_scan.dart
+++ b/lib/qr_code_dart_scan.dart
@@ -1,6 +1,6 @@
 library qr_code_dart_scan;
 
-export 'package:camera/camera.dart' show XFile;
+export 'package:camera/camera.dart';
 export 'package:zxing_lib/zxing.dart';
 
 export 'src/decoder/qr_code_dart_scan_decoder.dart';


### PR DESCRIPTION
The qr_code_dart_scan package only exports the Xfile class from the camera package, and this way I cannot pass the FlashMode parameters in the setFlashMode function of the QRCodeDartScanController controller, and no other parameters from the camera package.

To be able to solve the problem, I try to import the camera package manually into my project, but I believe this is not the best solution.

suggestion: export all functions from the camera package. currently only the Xfile class is exported