### PR TITLE
Camera orientation lock

### DIFF
--- a/lib/src/qr_code_dart_scan_controller.dart
+++ b/lib/src/qr_code_dart_scan_controller.dart
@@ -22,6 +22,7 @@ class PreviewState extends Equatable {
   final bool initialized;
   final TypeScan typeScan;
   final TypeCamera typeCamera;
+  final DeviceOrientation? lockCaptureOrientation;
 
   const PreviewState({
     this.result,
@@ -29,6 +30,7 @@ class PreviewState extends Equatable {
     this.initialized = false,
     this.typeScan = TypeScan.live,
     this.typeCamera = TypeCamera.back,
+    this.lockCaptureOrientation,
   });
 
   PreviewState copyWith({
@@ -76,6 +78,7 @@ class QRCodeDartScanController {
     QRCodeDartScanResolutionPreset resolutionPreset,
     Duration intervalScan,
     OnResultInterceptorCallback? onResultInterceptor,
+    DeviceOrientation? lockCaptureOrientation,
   ) async {
     _scanInvertedQRCode = scanInvertedQRCode;
     state.value = state.value.copyWith(
@@ -91,7 +94,9 @@ class QRCodeDartScanController {
         ),
       onResultInterceptor: onResultInterceptor,
     );
-    _lockCaptureOrientation = _lockCaptureOrientation;
+    if (lockCaptureOrientation != null) {
+      _lockCaptureOrientation = lockCaptureOrientation;
+    }
     await _initController(typeCamera);
   }
 
@@ -107,16 +112,19 @@ class QRCodeDartScanController {
       enableAudio: false,
       imageFormatGroup: ImageFormatGroup.yuv420,
     );
+
     await cameraController?.initialize();
+
+    if (_lockCaptureOrientation != null) {
+      cameraController?.lockCaptureOrientation(_lockCaptureOrientation!);
+    }
+
     if (state.value.typeScan == TypeScan.live) {
       cameraController?.startImageStream(_imageStream);
     }
     state.value = state.value.copyWith(
       initialized: true,
     );
-    if (_lockCaptureOrientation != null) {
-      await cameraController?.lockCaptureOrientation(_lockCaptureOrientation!);
-    }
   }
 
   Future<CameraDescription> _getCamera(TypeCamera typeCamera) async {

--- a/lib/src/qr_code_dart_scan_controller.dart
+++ b/lib/src/qr_code_dart_scan_controller.dart
@@ -1,5 +1,6 @@
 import 'package:equatable/equatable.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:qr_code_dart_scan/qr_code_dart_scan.dart';
 import 'package:qr_code_dart_scan/src/util/extensions.dart';
 
@@ -60,12 +61,12 @@ class QRCodeDartScanController {
   final ValueNotifier<PreviewState> state = ValueNotifier(const PreviewState());
   CameraController? cameraController;
   QRCodeDartScanDecoder? _codeDartScanDecoder;
-  QRCodeDartScanResolutionPreset _resolutionPreset =
-      QRCodeDartScanResolutionPreset.medium;
+  QRCodeDartScanResolutionPreset _resolutionPreset = QRCodeDartScanResolutionPreset.medium;
   bool scanEnabled = true;
   bool _scanInvertedQRCode = false;
   Duration _intervalScan = const Duration(seconds: 1);
   _LastScan? _lastScan;
+  DeviceOrientation? _lockCaptureOrientation;
 
   Future<void> config(
     List<BarcodeFormat> formats,
@@ -90,6 +91,7 @@ class QRCodeDartScanController {
         ),
       onResultInterceptor: onResultInterceptor,
     );
+    _lockCaptureOrientation = _lockCaptureOrientation;
     await _initController(typeCamera);
   }
 
@@ -112,6 +114,9 @@ class QRCodeDartScanController {
     state.value = state.value.copyWith(
       initialized: true,
     );
+    if (_lockCaptureOrientation != null) {
+      await cameraController?.lockCaptureOrientation(_lockCaptureOrientation!);
+    }
   }
 
   Future<CameraDescription> _getCamera(TypeCamera typeCamera) async {

--- a/lib/src/qr_code_dart_scan_view.dart
+++ b/lib/src/qr_code_dart_scan_view.dart
@@ -1,5 +1,6 @@
 import 'package:camera/camera.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:qr_code_dart_scan/src/qr_code_dart_scan_controller.dart';
 import 'package:qr_code_dart_scan/src/util/extensions.dart';
 import 'package:qr_code_dart_scan/src/util/qr_code_dart_scan_resolution_preset.dart';
@@ -46,6 +47,7 @@ class QRCodeDartScanView extends StatefulWidget {
   final TakePictureButtonBuilder? takePictureButtonBuilder;
   final Duration intervalScan;
   final OnResultInterceptorCallback? onResultInterceptor;
+  final DeviceOrientation? lockCaptureOrientation;
   const QRCodeDartScanView({
     Key? key,
     this.typeCamera = TypeCamera.back,
@@ -61,14 +63,14 @@ class QRCodeDartScanView extends StatefulWidget {
     this.heightPreview = double.maxFinite,
     this.intervalScan = const Duration(seconds: 1),
     this.onResultInterceptor,
+    this.lockCaptureOrientation,
   }) : super(key: key);
 
   @override
   QRCodeDartScanViewState createState() => QRCodeDartScanViewState();
 }
 
-class QRCodeDartScanViewState extends State<QRCodeDartScanView>
-    with WidgetsBindingObserver {
+class QRCodeDartScanViewState extends State<QRCodeDartScanView> with WidgetsBindingObserver {
   late QRCodeDartScanController controller;
   bool initialized = false;
 
@@ -174,8 +176,7 @@ class QRCodeDartScanViewState extends State<QRCodeDartScanView>
               ),
             ),
           ),
-          if (controller.state.value.typeScan == TypeScan.takePicture)
-            _buildButton(),
+          if (controller.state.value.typeScan == TypeScan.takePicture) _buildButton(),
           widget.child ?? const SizedBox.shrink(),
         ],
       ),

--- a/lib/src/qr_code_dart_scan_view.dart
+++ b/lib/src/qr_code_dart_scan_view.dart
@@ -124,6 +124,7 @@ class QRCodeDartScanViewState extends State<QRCodeDartScanView> with WidgetsBind
       widget.resolutionPreset,
       widget.intervalScan,
       widget.onResultInterceptor,
+      widget.lockCaptureOrientation,
     );
   }
 


### PR DESCRIPTION
We had a use case in our app that we needed to lock the camera orientation as we scan VIN barcodes on a regular basis that are often vertical.  

I've add the ability on the Camera Controller to optionally add lockCaptureOrientation: DeviceOrientation.portraitUp for example. Not sure if anyone else needs the ability to do this but we did so I wanted to pass it along if was of any use.  

`QRCodeDartScanView(
            scanInvertedQRCode: true,
            lockCaptureOrientation: DeviceOrientation.portraitUp,
            onCapture: (Result result) {}
)`